### PR TITLE
Add internationalisation support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM java:openjdk-7u65-jdk
 
-RUN apt-get update && apt-get install -y wget git curl zip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y wget git curl zip language-pack-en && rm -rf /var/lib/apt/lists/*
 
 ENV JENKINS_HOME /var/jenkins_home
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -17,6 +17,7 @@ copy_reference_file() {
 		cp -r /usr/share/jenkins/ref/${rel} /var/jenkins_home/${rel}; 
 	fi; 
 }
+export LC_LANG="en_US.UTF-8"
 export -f copy_reference_file
 echo "--- Copying files at $(date)" >> $COPY_REFERENCE_FILE_LOG
 find /usr/share/jenkins/ref/ -type f -exec bash -c 'copy_reference_file {}' \;


### PR DESCRIPTION
This avoid issue like "Malformed input or input contains unmappable characters" while Jenkins wipeout repository and folders with accented characters
Reference: https://issues.jenkins-ci.org/browse/JENKINS-20410
